### PR TITLE
Fix video preview breaks when media has no audio track

### DIFF
--- a/src/video.js
+++ b/src/video.js
@@ -28,7 +28,7 @@ const generateVideoPreview = (filePath, start, end, size = "m", mute = false) =>
       "-map",
       "0:v:0",
       "-map",
-      "0:a:0",
+      "0:a:0?",
       "-vf",
       `scale=${{ l: 640, m: 320, s: 160 }[size]}:-2`,
       "-c:v",


### PR DESCRIPTION
Fixes media preview support for audioless media as mentioned in #153.